### PR TITLE
feat: 대체화폐 시세 탭 기능 구현

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,6 +1,7 @@
 import {Link} from 'react-router-dom'
 import {SearchBar} from './search-bar/SearchBar'
 import React from "react";
+import {CurrencyTicker} from "./currency-ticker/CurrencyTicker.tsx";
 
 interface LayoutProps {
     children: React.ReactNode
@@ -41,12 +42,6 @@ export const Layout = ({children}: LayoutProps) => {
                                 홈
                             </Link>
                             <Link
-                                to="/register"
-                                className="text-gray-700 hover:text-gray-900 font-medium transition-colors"
-                            >
-                                아이템 등록
-                            </Link>
-                            <Link
                                 to="/my-items"
                                 className="text-gray-700 hover:text-gray-900 font-medium transition-colors"
                             >
@@ -56,6 +51,7 @@ export const Layout = ({children}: LayoutProps) => {
                     </div>
                 </div>
             </nav>
+            <CurrencyTicker/>
 
             {/* Main Content */}
             <main data-testid="main-content" className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">

--- a/src/components/currency-ticker/CurrencyTicker.tsx
+++ b/src/components/currency-ticker/CurrencyTicker.tsx
@@ -1,0 +1,94 @@
+import React, {useEffect, useMemo, useRef, useState} from 'react'
+import {representativeCurrencies} from '../../constants/representative-currencies'
+import {useDarkerDbApi} from '../../hooks/useDarkerDBApi'
+
+interface MarketData {
+    price: number
+}
+
+const CurrencyItem: React.FC<{ currency: typeof representativeCurrencies[0] }> = ({currency}) => {
+    const endpoint = `/market?item=${currency.name}&has_sold=true&order=desc&limit=10`
+    const {data, loading, error} = useDarkerDbApi<MarketData[]>(endpoint)
+    const [showName, setShowName] = useState(true)
+    const containerRef = useRef<HTMLDivElement>(null)
+
+    const averagePrice = useMemo(() => {
+        if (!data || data.length === 0) return 0
+        const total = data.reduce((sum, item) => sum + item.price, 0)
+        return Math.round(total / data.length)
+    }, [data])
+
+    useEffect(() => {
+        const checkOverflow = () => {
+            if (containerRef.current) {
+                const container = containerRef.current
+                const isOverflowing = container.scrollWidth > container.offsetWidth
+
+                console.log(container.scrollWidth, container.clientWidth)
+                setShowName(!isOverflowing)
+            }
+        }
+
+        checkOverflow()
+        window.addEventListener('resize', checkOverflow)
+        return () => window.removeEventListener('resize', checkOverflow)
+    }, [data, loading, error])
+
+    if (loading) {
+        return (
+            <div className="flex items-center space-x-2 animate-pulse">
+                <div className="w-6 h-6 bg-gray-300 rounded"></div>
+                <span className="text-sm font-medium text-gray-600">{currency.name}</span>
+                <span className="text-sm text-gray-400">로딩중...</span>
+            </div>
+        )
+    }
+
+    if (error) {
+        return (
+            <div className="flex items-center space-x-2">
+                <img
+                    src={`${import.meta.env.VITE_API_DARKER_DB_URL}/items/${currency.id}/icon`}
+                    alt={currency.name}
+                    className="w-6 h-6"
+                    onError={(e) => {
+                        e.currentTarget.style.display = 'none'
+                    }}
+                />
+                <span className="text-sm font-medium text-gray-600">{currency.name}</span>
+                <span className="text-sm text-red-500">오류</span>
+            </div>
+        )
+    }
+
+    return (
+        <div ref={containerRef} className="flex items-center space-x-2 min-w-0 flex-shrink-0">
+            <img
+                src={`${import.meta.env.VITE_API_DARKER_DB_URL}/items/${currency.id}/icon`}
+                alt={currency.name}
+                className="h-8 flex-shrink-0"
+                onError={(e) => {
+                    e.currentTarget.style.display = 'none'
+                }}
+            />
+            {showName && <span className="text-sm font-medium text-gray-700 truncate">{currency.name}</span>}
+            <span className="text-sm text-green-600 font-semibold flex-shrink-0">
+                {averagePrice.toLocaleString()}
+            </span>
+        </div>
+    )
+}
+
+export const CurrencyTicker: React.FC = () => {
+    return (
+        <div className="bg-gray-100 border-b border-gray-200 py-4">
+            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+                <div className="flex items-center justify-center space-x-8 overflow-x-auto">
+                    {representativeCurrencies.map((currency) => (
+                        <CurrencyItem key={currency.name} currency={currency}/>
+                    ))}
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/src/constants/representative-currencies.ts
+++ b/src/constants/representative-currencies.ts
@@ -9,5 +9,20 @@ export const representativeCurrencies = [
         "name": "Gold Coin Chest",
         "id": "GoldCoinChest",
         "archetype": "GoldCoinChest"
+    },
+    {
+        "name": "Golden Key",
+        "id": "GoldenKey",
+        "archetype": "GoldenKey"
+    },
+    {
+        "name": "Troll Pelt",
+        "id": "TrollPelt",
+        "archetype": "TrollPelt"
+    },
+    {
+        "name": "Spectral Coinbag",
+        "id": "SpectralCoinbag",
+        "archetype": "SpectralCoinbag"
     }
 ]


### PR DESCRIPTION
- Layout 하단 대체화폐 탭 구현
- representative-currencies 정적 변수에 대체화폐 추가
- DarkerDB market API 활용한 평균 시세 표기
  - 최근 10개의 판매 금액의 평균